### PR TITLE
provide paging object to getUserTimeline

### DIFF
--- a/twitter4j-twitter-client/src/main/java/de/fjobilabs/botometer/twitterclient/twitter4j/Twitter4JTwitterClient.java
+++ b/twitter4j-twitter-client/src/main/java/de/fjobilabs/botometer/twitterclient/twitter4j/Twitter4JTwitterClient.java
@@ -63,7 +63,7 @@ public class Twitter4JTwitterClient implements TwitterClient {
         Paging paging = new Paging();
         paging.setCount(count);
         try {
-            return this.twitter.getUserTimeline(userId).stream().map(Twitter4JTweet::new).collect(Collectors.toList());
+            return this.twitter.getUserTimeline(userId, paging).stream().map(Twitter4JTweet::new).collect(Collectors.toList());
         } catch (TwitterException e) {
             throw new TwitterClientException("Failed to get user timeline for userId: " + userId, e);
         }
@@ -74,7 +74,7 @@ public class Twitter4JTwitterClient implements TwitterClient {
         Paging paging = new Paging();
         paging.setCount(count);
         try {
-            return this.twitter.getUserTimeline(screenName).stream().map(Twitter4JTweet::new)
+            return this.twitter.getUserTimeline(screenName, paging).stream().map(Twitter4JTweet::new)
                 .collect(Collectors.toList());
         } catch (TwitterException e) {
             throw new TwitterClientException("Failed to get user timeline for screenName: " + screenName, e);


### PR DESCRIPTION
If paging object with the defined count is not provided to getUserTimeline it will always return only 20 tweets. This leads to very different botometer results.